### PR TITLE
Fixed NoMethodError when domain name is missing

### DIFF
--- a/lib/win32/file/security/helper.rb
+++ b/lib/win32/file/security/helper.rb
@@ -8,6 +8,8 @@ class String
   # Read a wide character string up until the first double null, and delete
   # any remaining null characters.
   def wstrip
+    return self.encode(Encoding.default_external) if empty?
+
     self.force_encoding('UTF-16LE').encode('UTF-8',:invalid=>:replace,:undef=>:replace).split("\x00")[0].encode(Encoding.default_external)
   end
 end


### PR DESCRIPTION
I got `NoMethodError` when a user of acl doesn't belong to any domain like blow.

```
C:\>cacls C:\ProgramData\Microsoft\IdentityCRL\INT\ppcrlconfig600.dll
C:\ProgramData\Microsoft\IdentityCRL\INT\ppcrlconfig600.dll NT AUTHORITY\SYSTEM:(ID)F
                                                            BUILTIN\Administrators:(ID)F
                                                            BUILTIN\Users:(ID)R
                                                            Everyone:(ID)R
```

`Everyone` has no domain name. 
In this case, `File.get_permissions` throws `NoMethodError`.

```
[5] pry(main)> require 'win32/file/security'
=> true
[6] pry(main)>
[7] pry(main)>
[8] pry(main)>
[9] pry(main)> File.get_permissions 'C:/ProgramData/Microsoft/IdentityCRL/INT/ppcrlconfig600.dll'
NoMethodError: undefined method `encode' for nil:NilClass
from C:/Ruby21/lib/ruby/gems/2.1.0/gems/win32-file-security-1.0.5/lib/win32/file/security/helper.rb:11:in `wstrip'
```

That's because `String#split` returns an empty array if `self` is empty and the first element becomes nil in [this line](https://github.com/djberg96/win32-file-security/blob/master/lib/win32/file/security/helper.rb#L11).

So I made a small change to fix it.

```
[4] pry(main)> require_relative 'lib/win32/file/security'
=> true
[5] pry(main)>
[6] pry(main)>
[7] pry(main)> File.get_permissions 'C:/ProgramData/Microsoft/IdentityCRL/INT/ppcrlconfig600.dll'
=> {"NT AUTHORITY\\SYSTEM"=>2032127, "BUILTIN\\Administrators"=>2032127, "BUILTIN\\Users"=>1179817, "Everyone"=>1179817}
```
