### PR TITLE
Check for account name with no backslash

### DIFF
--- a/lib/win32/file/security.rb
+++ b/lib/win32/file/security.rb
@@ -407,6 +407,9 @@ class File
 
         if ['BUILTIN', 'NT AUTHORITY'].include?(server.upcase)
           wide_server = nil
+        elsif account.nil?
+          wide_server = nil
+          account = server
         else
           wide_server = server.wincode
         end

--- a/test/test_win32_file_security_ownership.rb
+++ b/test/test_win32_file_security_ownership.rb
@@ -37,7 +37,7 @@ class TC_Win32_File_Security_Ownership < Test::Unit::TestCase
     @@domain = in_domain?
 
     if Win32::Security.elevated_security?
-      Sys::Admin.add_user(:name => @@temp, :description => "Delete Me")
+      Sys::Admin.add_user(:name => @@temp, :description => "Delete Me", :password => 'a1b2c3D4ekd92!38d')
     end
   end
 


### PR DESCRIPTION
If account has no backslash, such as `Everyone`, then treat it as having
no server name.

This fixes #4
